### PR TITLE
Fix issue #67: Broken django-cms page type display

### DIFF
--- a/djangocms_page_sitemap/cms_toolbars.py
+++ b/djangocms_page_sitemap/cms_toolbars.py
@@ -21,6 +21,9 @@ class PageSitemapPropertiesMeta(CMSToolbar):
         if not self.page:
             # Nothing to do
             return
+        if self.page.is_page_type:
+            # If a page type nothing to do
+            return
 
         # check global permissions if CMS_PERMISSIONS is active
         if get_cms_setting("PERMISSION"):


### PR DESCRIPTION
Excludes django-cms page types from sitemap

# Description
Fix-issue #67
## References
https://github.com/nephila/djangocms-page-sitemap/issues/67

